### PR TITLE
#187419015 Admin should be able to acivate/reactivate an account for various reasons.

### DIFF
--- a/src/@types/admin/AccounEnabling.ts
+++ b/src/@types/admin/AccounEnabling.ts
@@ -1,0 +1,7 @@
+export type EnableAccountState = {
+	isLoading: boolean;
+	error: string | null;
+	message: string | null;
+	enable: string;
+	reason: string;
+};

--- a/src/components/adminDashboard/getUser.tsx
+++ b/src/components/adminDashboard/getUser.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ReactNode, useEffect, useState } from 'react';
 import { IoMdMore } from 'react-icons/io';
@@ -30,7 +31,9 @@ const GetUser = (props: getUserType) => {
 	const itemsPerPage = 8;
 
 	useEffect(() => {
-		dispatch(getRoles()).unwrap();
+		if (!roles) {
+			dispatch(getRoles()).unwrap();
+		}
 	}, [dispatch]);
 
 	useEffect(() => {
@@ -38,7 +41,9 @@ const GetUser = (props: getUserType) => {
 	}, [searchQuery]);
 
 	useEffect(() => {
-		dispatch(getUser()).unwrap();
+		if (data.length === 0) {
+			dispatch(getUser()).unwrap();
+		}
 	}, [dispatch]);
 	const getRoleName = (roleId: string) => {
 		return roles?.data.find((role: roleType) => role.id === roleId).roleName;

--- a/src/pages/Admin/EditUserRoles.tsx
+++ b/src/pages/Admin/EditUserRoles.tsx
@@ -1,21 +1,14 @@
 import { useParams } from 'react-router-dom';
-
 import EditUserForm from '../../components/Forms/editUserForm';
 import GetUser from '../../components/adminDashboard/getUser';
 import { userType } from '../../@types/userType';
-import { useAppDispatch, useAppSelector } from '../../redux/hooks/hooks';
-import { useEffect } from 'react';
-import { getUser } from '../../redux/features/getUserSlice';
+import { useAppSelector } from '../../redux/hooks/hooks';
 
 const EditUser = () => {
 	const { id } = useParams<string>();
-	const dispatch = useAppDispatch();
 	const users = useAppSelector(
 		(state) => state.allUsers.data[state.allUsers.data.length - 1],
 	);
-	useEffect(() => {
-		dispatch(getUser()).unwrap();
-	}, [dispatch]);
 
 	const getUserInfo = () => {
 		return users?.data.filter((item: userType) => item?.id === id) || '';

--- a/src/redux/features/EnableAccountSlice.ts
+++ b/src/redux/features/EnableAccountSlice.ts
@@ -1,0 +1,85 @@
+import { PayloadAction, createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import API from '../../utils/api';
+import { DynamicData } from '../../@types/DynamicData';
+import { EnableAccountState } from '../../@types/admin/AccounEnabling';
+
+export interface EnableAccountType {
+	id?: string;
+	isAccountActive: string;
+	reason: string;
+}
+
+export const enableAccount = createAsyncThunk<
+	EnableAccountResponse,
+	EnableAccountType,
+	{ rejectValue: DynamicData }
+>(
+	'enableAccount',
+	async (
+		{ id, isAccountActive, reason }: EnableAccountType,
+		{ rejectWithValue },
+	) => {
+		try {
+			const { data } = await API.patch(`/users/${id}/account-status`, {
+				isAccountActive,
+				reason,
+			});
+			return data;
+		} catch (error) {
+			return rejectWithValue((error as DynamicData).response);
+		}
+	},
+);
+
+const initialEnableAccountState: EnableAccountState = {
+	isLoading: false,
+	error: null,
+	message: null,
+	enable: 'false',
+	reason: '',
+};
+
+type EnableAccountResponse = {
+	message: string;
+	status: string;
+};
+
+const enableAccountSlice = createSlice({
+	name: 'enableAccount',
+	initialState: initialEnableAccountState,
+	reducers: {
+		setEnable: (state, action: PayloadAction<string>) => {
+			state.enable = action.payload;
+		},
+		setReason: (state, action: PayloadAction<string>) => {
+			state.reason = action.payload;
+		},
+		resetField: (state) => {
+			state.reason = '';
+		},
+	},
+	extraReducers: (builder) => {
+		builder
+			.addCase(enableAccount.pending, (state) => {
+				state.isLoading = true;
+				state.error = null;
+			})
+			.addCase(
+				enableAccount.fulfilled,
+				(state, action: PayloadAction<EnableAccountResponse>) => {
+					state.isLoading = false;
+					state.message = action.payload.message;
+					state.error = null;
+				},
+			)
+			.addCase(
+				enableAccount.rejected,
+				(state, action: PayloadAction<DynamicData | undefined>) => {
+					state.isLoading = false;
+					state.error = action.payload?.data?.message || 'An error occurred';
+				},
+			);
+	},
+});
+export const { setEnable, setReason, resetField } = enableAccountSlice.actions;
+export default enableAccountSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -14,6 +14,7 @@ import profileSlice from './features/userUpdateSlice';
 import googleSlice from './features/googleSlice';
 import VerifyAccountSlice from './features/VerifyAccountSlice';
 import notificationSlice from './features/notificationSlice';
+import EnableAccountSlice from './features/EnableAccountSlice';
 
 export const store = configureStore({
 	reducer: {
@@ -32,6 +33,7 @@ export const store = configureStore({
 		allRoles: getRolesSlice,
 		google: googleSlice,
 		notifications: notificationSlice,
+		enableAccount: EnableAccountSlice,
 	},
 });
 

--- a/src/utils/MockNavigate.ts
+++ b/src/utils/MockNavigate.ts
@@ -1,0 +1,4 @@
+// mockNavigate.ts
+export const mockNavigate = () => {}; // Define a mock implementation
+const useNavigate = () => mockNavigate;
+export default useNavigate;

--- a/src/validations/EnableDisable.validation.ts
+++ b/src/validations/EnableDisable.validation.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const EnableDisableSchema = z.object({
+	reason: z
+		.string({ message: 'Reason must be a string' })
+		.nonempty({ message: 'Reason field is required' }),
+});
+
+export type EnableDisableSchemaType = z.infer<typeof EnableDisableSchema>;

--- a/test/components/EnableDisableAcc.test.tsx
+++ b/test/components/EnableDisableAcc.test.tsx
@@ -1,0 +1,237 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { useNavigate, NavigateFunction } from 'react-router-dom';
+import { useAppDispatch, useAppSelector } from '../../src/redux/hooks/hooks';
+import {
+	enableAccount,
+	setEnable,
+	resetField,
+} from '../../src/redux/features/EnableAccountSlice';
+import useToast from '../../src/hooks/useToast';
+import { DynamicData } from '../../src/@types/DynamicData';
+import { ThunkDispatch } from '@reduxjs/toolkit';
+import EditUserForm from '../../src/components/Forms/editUserForm';
+
+vi.mock('../../src/redux/hooks/hooks', () => ({
+	useAppDispatch: vi.fn(),
+	useAppSelector: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+	useNavigate: vi.fn(),
+}));
+
+vi.mock('../../src/redux/features/EnableAccountSlice', () => ({
+	enableAccount: vi.fn(),
+	setEnable: vi.fn(),
+	resetField: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useToast', () => ({
+	default: vi.fn(),
+}));
+
+describe('handleEnableDisableSubmit', () => {
+	let dispatch: ThunkDispatch<any, any, any>;
+	let navigate: NavigateFunction;
+	let showSuccessMessage: (message: string) => void;
+	let showErrorMessage: (message: string) => void;
+
+	beforeEach(() => {
+		dispatch = vi.fn() as unknown as ThunkDispatch<any, any, any>;
+		navigate = vi.fn() as unknown as NavigateFunction;
+		showSuccessMessage = vi.fn();
+		showErrorMessage = vi.fn();
+		(useAppDispatch as any).mockReturnValue(dispatch);
+		(useNavigate as any).mockReturnValue(navigate);
+		(useToast as any).mockReturnValue({ showSuccessMessage, showErrorMessage });
+		(useAppSelector as any).mockReturnValue({
+			allRoles: {
+				data: [{ id: '1', isActive: true }],
+			},
+		});
+	});
+
+	let id = '123';
+	const reason = 'Test reason';
+
+	let handleEnableDisableSubmit = async (newEnable: string) => {
+		try {
+			if (id) {
+				const res = await dispatch(
+					enableAccount({ id, isAccountActive: newEnable, reason }),
+				).unwrap();
+				showSuccessMessage(res.message);
+				navigate('/dashboard/users');
+			}
+		} catch (e) {
+			const err = e as DynamicData;
+			showErrorMessage(
+				err?.response?.data?.message ||
+					err?.message ||
+					'Unknown error occurred! Please try again!',
+			);
+		}
+	};
+
+	const handleEnableDisableClick = (newEnable: string) => {
+		handleEnableDisableSubmit(newEnable);
+		dispatch(setEnable(newEnable));
+		dispatch(resetField());
+	};
+
+	it('should enable/disable account successfully', async () => {
+		(dispatch as any).mockReturnValue({
+			unwrap: vi.fn().mockResolvedValue({ message: 'Success' }),
+		});
+
+		await handleEnableDisableSubmit('true');
+
+		expect(dispatch).toHaveBeenCalledWith(
+			enableAccount({
+				id: '123',
+				isAccountActive: 'true',
+				reason: 'Test reason',
+			}),
+		);
+		expect(showSuccessMessage).toHaveBeenCalledWith('Success');
+		expect(navigate).toHaveBeenCalledWith('/dashboard/users');
+	});
+
+	it('should show error message on failure', async () => {
+		const errorMessage = 'Error occurred';
+		(dispatch as any).mockReturnValue({
+			unwrap: vi
+				.fn()
+				.mockRejectedValue({ response: { data: { message: errorMessage } } }),
+		});
+
+		await handleEnableDisableSubmit('true');
+
+		expect(dispatch).toHaveBeenCalledWith(
+			enableAccount({
+				id: '123',
+				isAccountActive: 'true',
+				reason: 'Test reason',
+			}),
+		);
+		expect(showErrorMessage).toHaveBeenCalledWith(errorMessage);
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	it('should show default error message on failure', async () => {
+		(dispatch as any).mockReturnValue({
+			unwrap: vi.fn().mockRejectedValue({}),
+		});
+
+		await handleEnableDisableSubmit('true');
+
+		expect(dispatch).toHaveBeenCalledWith(
+			enableAccount({
+				id: '123',
+				isAccountActive: 'true',
+				reason: 'Test reason',
+			}),
+		);
+		expect(showErrorMessage).toHaveBeenCalledWith(
+			'Unknown error occurred! Please try again!',
+		);
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	it('should navigate to dashboard on success', async () => {
+		(dispatch as any).mockReturnValue({
+			unwrap: vi.fn().mockResolvedValue({ message: 'Success' }),
+		});
+
+		await handleEnableDisableSubmit('true');
+
+		expect(navigate).toHaveBeenCalledWith('/dashboard/users');
+	});
+
+	it('should not navigate to dashboard on failure', async () => {
+		(dispatch as any).mockReturnValue({
+			unwrap: vi.fn().mockRejectedValue({}),
+		});
+
+		await handleEnableDisableSubmit('true');
+
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	it('should show success message on success', async () => {
+		(dispatch as any).mockReturnValue({
+			unwrap: vi.fn().mockResolvedValue({ message: 'Success' }),
+		});
+
+		await handleEnableDisableSubmit('true');
+
+		expect(showSuccessMessage).toHaveBeenCalledWith('Success');
+	});
+
+	it('should not show success message on failure', async () => {
+		(dispatch as any).mockReturnValue({
+			unwrap: vi.fn().mockRejectedValue({}),
+		});
+
+		await handleEnableDisableSubmit('true');
+
+		expect(showSuccessMessage).not.toHaveBeenCalled();
+	});
+
+	it('should render EditUserForm without crashing', () => {
+		render(<EditUserForm id="123" useR={[{ id: '1', isActive: true }]} />);
+	});
+
+	it('should call handleEnableDisableSubmit, setEnable, and resetField on handleEnableDisableClick', async () => {
+		(setEnable as any).mockReturnValue({ type: 'setEnable' });
+		(resetField as any).mockReturnValue({ type: 'resetField' });
+
+		// Mock handleEnableDisableSubmit
+		const mockHandleEnableDisableSubmit = vi.fn();
+		const originalHandleEnableDisableSubmit = handleEnableDisableSubmit;
+		handleEnableDisableSubmit = mockHandleEnableDisableSubmit;
+
+		const newEnable = 'false';
+		handleEnableDisableClick(newEnable);
+
+		expect(mockHandleEnableDisableSubmit).toHaveBeenCalledWith(newEnable);
+		expect(dispatch).toHaveBeenCalledWith(setEnable(newEnable));
+		expect(dispatch).toHaveBeenCalledWith(resetField());
+
+		// Restore original handleEnableDisableSubmit
+		handleEnableDisableSubmit = originalHandleEnableDisableSubmit;
+	});
+
+	// New test to cover when id is not present
+	it('should not call dispatch when id is not present', async () => {
+		const idBackup = id;
+		const localId = '';
+		const handleEnableDisableSubmit = async (newEnable: string) => {
+			try {
+				if (localId) {
+					const res = await dispatch(
+						enableAccount({ id: localId, isAccountActive: newEnable, reason }),
+					).unwrap();
+					showSuccessMessage(res.message);
+					navigate('/dashboard/users');
+				}
+			} catch (e) {
+				const err = e as DynamicData;
+				showErrorMessage(
+					err.response.data.message ||
+						err?.message ||
+						'Unknown error occurred! Please try again!',
+				);
+			}
+		};
+
+		await handleEnableDisableSubmit('true');
+
+		expect(dispatch).not.toHaveBeenCalled();
+
+		// Restore id
+		id = idBackup;
+	});
+});

--- a/test/pages/admin/DashboardGetUser.test.tsx
+++ b/test/pages/admin/DashboardGetUser.test.tsx
@@ -74,14 +74,13 @@ describe('Dashboard getuser page', () => {
 				<AdminDashboardAllUser />
 			</AllProvider>,
 		);
-
+	};
+	test('it should render table', async () => {
+		await renderComponent();
 		const loader = screen.getByRole('progressbar');
 		expect(loader).toBeInTheDocument();
 		await waitForElementToBeRemoved(loader);
 		expect(loader).not.toBeInTheDocument();
-	};
-	test('it should render table', async () => {
-		await renderComponent();
 		const firstName = screen.getByText(/kabera/i);
 		const lastName = screen.getByText(/joe/i);
 		const email = screen.getByText(/johndoe1@example.com/i);

--- a/test/pages/admin/EdituserRole.test.tsx
+++ b/test/pages/admin/EdituserRole.test.tsx
@@ -109,14 +109,11 @@ describe('Dashboard Edit role page', () => {
 					</div>
 				</AllProvider>,
 			);
-			const loader = screen.getByTestId('role-form-loader');
-			expect(loader).toBeInTheDocument();
-			await waitForElementToBeRemoved(loader);
-			expect(loader).not.toBeInTheDocument();
 		}
 	};
 	test('it should test edit role page of user', async () => {
 		await renderEditusePage();
+
 		const firstName = screen.getByText(/kabera/i);
 		const lastName = screen.getByText(/joe/i);
 		const email = screen.getByText(/johndoe1@example.com/i);


### PR DESCRIPTION
## What does this PR do?
Enabling/Disabling User account by admin
## Description of Task to be completed?
- Enabling user account to make it active
- Disabling user account in case he/she violates `App's terms and conditions`
## How should this be manually tested?
- Clone this repository, go to the branch `ft-accountEnable-disable-187419015`
- Have `.env` file with proper variables
- install all packages using `npm install`
- run `npm run dev` 
- login as admin and try eabling/disabling account

## What are the relevant pivotal tracker/Trello stories?
#187419015