### PR TITLE
#187419030 user should see recommended product when viewing single product

### DIFF
--- a/src/components/Recommend.tsx
+++ b/src/components/Recommend.tsx
@@ -1,0 +1,62 @@
+import ProductPageAddToCart from './carts/ProductPageAddToCart';
+import Button from './buttons/Button';
+import { FaHeart, FaStar } from 'react-icons/fa6';
+import { DynamicData } from '../@types/DynamicData';
+
+function RecommendedDesign({ item }: DynamicData) {
+	return (
+		<div
+			key={item.id}
+			className="product_card bg-neutral-white p-2 m-2 rounded-md shadow"
+		>
+			<div className="card_profile p-2 w-full flex-grow">
+				<div className="w-full h-48 relative">
+					<div className="w-full overflow-hidden flex shadow h-48">
+						<img
+							src={item.images && item.images[0]}
+							alt="card_profile"
+							className="w-full h-full object-cover rounded-lg"
+						/>
+					</div>
+					<ProductPageAddToCart productId={item.id} />
+					{item.discount > 0 && (
+						<div className="discount absolute p-1 rounded bg-action-warning text-neutral-white -right-2 -top-2 font-bold">
+							{item.discount} %
+						</div>
+					)}
+				</div>
+			</div>
+			<div className="card_description pl-2 flex-grow">
+				<h1 className="py-2">
+					{item.name.length > 20 ? item.name.slice(0, 20) + '...' : item.name}
+				</h1>
+				<div className="ratings flex">
+					<span className="ml-2 flex items-center gap-2">
+						<FaStar />
+						{item.ratings} ratings
+					</span>
+				</div>
+				<div className="price_wish flex justify-between items-center mt-2 gap-2 flex-wrap py-2">
+					<h1 className="text-2xl font-bold">
+						{item.price}
+						<small className="text-base font-normal"> RWF</small>
+					</h1>
+					<div className="wish flex items-center cursor-pointer">
+						<span className="mr-1">add to wish</span>
+						<FaHeart className=" text-action-error text-2xl cursor-pointer wish_btn" />
+					</div>
+				</div>
+			</div>
+			<div className="btn flex justify-center">
+				<Button
+					title="preview product"
+					url={`/products/${item.id}`}
+					otherStyles={' rounded-l-full rounded-r-full mt-2 font-semibold'}
+					buttonType={'button'}
+				/>
+			</div>
+		</div>
+	);
+}
+
+export default RecommendedDesign;

--- a/src/pages/RecommendedProduct.tsx
+++ b/src/pages/RecommendedProduct.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from '../redux/hooks/hooks';
+import { getRecommendedProducts } from '../redux/features/recommendedProductSlice';
+import { DynamicData } from '../@types/DynamicData';
+import RecommendedDesign from '../components/Recommend';
+import { ScaleLoader } from 'react-spinners';
+
+interface RecommendedProps {
+	prodId: string;
+}
+
+const RecommendedProduct = ({ prodId }: RecommendedProps) => {
+	const dispatch = useAppDispatch();
+	const { products, isLoading, error } = useAppSelector(
+		(state) => state.recommendedProducts,
+	);
+
+	useEffect(() => {
+		if (prodId) {
+			dispatch(getRecommendedProducts(prodId)).unwrap();
+		}
+	}, [dispatch, prodId]);
+
+	return (
+		<>
+			{Array.isArray(products) && products.length > 0 && (
+				<div className="text-2xl pb-2 mt-5">
+					<h2>You may also like:</h2>
+				</div>
+			)}
+
+			<div className="grid mobile:grid-cols-2 gap-5 pb-4 tablet:grid-cols-3 ipad:grid-cols-3 laptop:grid-cols-4 desktop:grid-cols-4 h-full rounded-md">
+				{isLoading && (
+					<div className="w-full h-full flex items-center justify-center absolute">
+						<ScaleLoader color="#256490" role="progressbar" />
+					</div>
+				)}
+				{error && <p>{error}</p>}
+				{products &&
+					products?.map((item: DynamicData) => (
+						<RecommendedDesign key={item.id} item={item} />
+					))}
+			</div>
+		</>
+	);
+};
+
+export default RecommendedProduct;

--- a/src/pages/SingleProduct.tsx
+++ b/src/pages/SingleProduct.tsx
@@ -19,6 +19,7 @@ import { fetchReview } from '../redux/features/getReviewSice';
 import { getSinleProducts } from '../redux/features/productSlice';
 import { useAppDispatch, useAppSelector } from '../redux/hooks/hooks';
 import fetchInfo from '../utils/userDetails';
+import RecommendedProduct from './RecommendedProduct';
 
 const SingleProduct = () => {
 	const { isLoading, singleProduct } = useAppSelector((state) => state.product);
@@ -250,6 +251,9 @@ const SingleProduct = () => {
 									isVisible={reviewForm}
 								/>
 							</div>
+						</div>
+						<div className="relative w-[98%] mobile:max-w-[80%] m-auto h-auto mobile:mt-5 laptop:mt-14 laptop:mb-[3%]">
+							<RecommendedProduct prodId={id as string} />
 						</div>
 					</>
 				)}

--- a/src/redux/features/recommendedProductSlice.ts
+++ b/src/redux/features/recommendedProductSlice.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { DynamicData } from '../../@types/DynamicData';
+import API from '../../utils/api';
+
+interface RecommendedProductsState {
+	isLoading: boolean;
+	error: string | null;
+	products: DynamicData;
+}
+
+const initialState: RecommendedProductsState = {
+	isLoading: false,
+	products: [],
+	error: null,
+};
+
+export const getRecommendedProducts = createAsyncThunk(
+	'recommendedProducts',
+	async (productId: string, { rejectWithValue }) => {
+		try {
+			const { data } = await API.post(`/products/recommended`, {
+				id: productId,
+			});
+			return data;
+		} catch (error) {
+			return rejectWithValue((error as DynamicData).response);
+		}
+	},
+);
+
+const recommendedProductsSlice = createSlice({
+	name: 'recommendedProducts',
+	initialState,
+	reducers: {},
+	extraReducers: (builder) => {
+		builder.addCase(getRecommendedProducts.pending, (state) => {
+			state.isLoading = true;
+			state.error = null;
+		});
+
+		builder.addCase(
+			getRecommendedProducts.fulfilled,
+			(state, action: PayloadAction<DynamicData>) => {
+				state.isLoading = false;
+				state.products = action.payload.data;
+			},
+		);
+
+		builder.addCase(
+			getRecommendedProducts.rejected,
+			(state, action: PayloadAction<any>) => {
+				state.isLoading = false;
+				state.error = action.payload;
+			},
+		);
+	},
+});
+
+export default recommendedProductsSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -25,6 +25,7 @@ import passwordSlice from './features/passwordUpdateSlice';
 import chatSlice from './features/chatSlice';
 import AllSaleSlice from './features/Sales/AllSaleSlice';
 import statisticsSlice from './features/statisticsSlice';
+import recommendedProductsSlice from './features/recommendedProductSlice';
 
 export const store = configureStore({
 	reducer: {
@@ -54,6 +55,7 @@ export const store = configureStore({
 		chat: chatSlice,
 		sales: AllSaleSlice,
 		statistics: statisticsSlice,
+		recommendedProducts: recommendedProductsSlice,
 	},
 });
 

--- a/test/pages/RecomendedProducts.test.tsx
+++ b/test/pages/RecomendedProducts.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import RecommendedProduct from '../../src/pages/RecommendedProduct';
+import recommendedProductSlice from '../../src/redux/features/recommendedProductSlice';
+import cartsSlice from '../../src/redux/features/cartSlice';
+import RecommendedDesign from '../../src/components/Recommend';
+import { configureStore } from '@reduxjs/toolkit';
+import { DynamicData } from '../../src/@types/DynamicData';
+import { describe, it, expect } from 'vitest';
+
+const mockProducts: DynamicData[] = [
+	{
+		id: '0b52e82c-70a7-4ff3-aad7-8f6a3e406f5c',
+		name: 'Product 1',
+		price: 100,
+		images: ['image1.png', 'image2.png', 'image3.png'],
+		discount: 2,
+		ratings: 3,
+	},
+	{
+		id: '0b52e82c-70a5-4ff3-aad7-8f6a3e406f5c',
+		name: 'Product 2',
+		price: 200,
+		images: ['image3.png', 'image4.png', 'image5.png'],
+		discount: 5,
+		ratings: 4,
+	},
+];
+
+const mockCartState = {
+	isLoading: false,
+	isInitialLoading: false,
+	carts: {
+		products: [],
+	},
+	numberOfItem: 0,
+	error: 'An unknown error occurred',
+};
+
+const createMockStore = (error: string | null) =>
+	configureStore({
+		reducer: {
+			recommendedProducts: recommendedProductSlice,
+			cart: cartsSlice,
+		},
+		preloadedState: {
+			recommendedProducts: {
+				products: mockProducts,
+				isLoading: false,
+				error,
+			},
+			cart: mockCartState,
+		},
+	});
+
+describe('RecommendedProduct component', () => {
+	const renderComponent = (store: ReturnType<typeof createMockStore>) => {
+		return render(
+			<Provider store={store}>
+				<MemoryRouter>
+					<RecommendedProduct prodId="0b52e82c-70a7-4ff3-aad7-8f6a3e406f5c" />
+				</MemoryRouter>
+			</Provider>,
+		);
+	};
+
+	it('should render the RecommendedProduct component', () => {
+		const store = createMockStore(null);
+		renderComponent(store);
+		expect(screen.getByText('You may also like:')).toBeInTheDocument();
+	});
+
+	it('should render RecommendedDesign components', () => {
+		const store = createMockStore(null);
+		renderComponent(store);
+		expect(screen.getByText('Product 1')).toBeInTheDocument();
+		expect(screen.getByText('Product 2')).toBeInTheDocument();
+	});
+
+	it('should include RecommendedDesign component in the rendering', () => {
+		const store = createMockStore(null);
+		renderComponent(store);
+		expect(RecommendedDesign).toBeTruthy();
+	});
+});

--- a/test/pages/Recommended.test.tsx
+++ b/test/pages/Recommended.test.tsx
@@ -1,0 +1,57 @@
+import RecommendedDesign from '../../src/components/Recommend';
+import { DynamicData } from '../../src/@types/DynamicData';
+import AllProvider from '../Utils/AllProvider';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+const data: DynamicData = {
+	id: '0b52e82c-70a7-4ff3-aad7-8f6a3e406f5c',
+	name: 'Product 1',
+	price: 100,
+	images: ['image1.png', 'image2.png', 'image3.png'],
+	discount: 2,
+	ratings: 3,
+};
+
+describe('Recommended products design', () => {
+	const renderComponent = () => {
+		return render(
+			<AllProvider>
+				<RecommendedDesign item={data} />
+			</AllProvider>,
+		);
+	};
+
+	it('should renders component without crashing', () => {
+		renderComponent();
+		expect(screen.getByText(/Product 1/i)).toBeInTheDocument();
+		screen.debug();
+	});
+
+	it('should render product props', () => {
+		renderComponent();
+		const imgElement = screen.getByAltText('card_profile');
+		expect(imgElement).toHaveAttribute('src', 'image1.png');
+		expect(screen.getByText('3 ratings')).toBeInTheDocument();
+		expect(screen.getByText('100')).toBeInTheDocument();
+		expect(screen.getByText(/RWF/)).toBeInTheDocument();
+	});
+
+	it('should render the discount badge if discount is greater than 0', () => {
+		renderComponent();
+		expect(screen.getByText(/2 %/)).toBeInTheDocument();
+	});
+
+	it('should render the product name shortened if length is more than 20 characters', () => {
+		const longNameProduct = {
+			...data,
+			name: 'This is a very long product name that exceeds twenty characters',
+		};
+		render(
+			<AllProvider>
+				<RecommendedDesign item={longNameProduct} />
+			</AllProvider>,
+		);
+		expect(screen.getByText('This is a very long ...')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

#### A buyer should see related/recommended products

## Description of Task to be completed?

Clone branch `ft-related-products-187419030` 

run `npm run dev` to test the feature

go to products, then single product
you should see *you may also like:* text and the list of related products

What are the relevant pivotal tracker/Trello stories?
#187419030