### PR TITLE
feat(notification): Marking one/all notification read

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1152,28 +1152,28 @@
 			"dev": true
 		},
 		"node_modules/@inquirer/confirm": {
-			"version": "3.1.14",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.14.tgz",
-			"integrity": "sha512-nbLSX37b2dGPtKWL3rPuR/5hOuD30S+pqJ/MuFiUEgN6GiMs8UMxiurKAMDzKt6C95ltjupa8zH6+3csXNHWpA==",
+			"version": "3.1.16",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.16.tgz",
+			"integrity": "sha512-DXgLZim+YVTk05zRywvFRfJt2Jje7sZ4DO6Ss9RpGtgXEd/T0IiTqubHWst0IazCwdPI9g/06Rtm/nm4IBFJBA==",
 			"dev": true,
 			"dependencies": {
-				"@inquirer/core": "^9.0.2",
-				"@inquirer/type": "^1.4.0"
+				"@inquirer/core": "^9.0.4",
+				"@inquirer/type": "^1.5.0"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/core": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.2.tgz",
-			"integrity": "sha512-nguvH3TZar3ACwbytZrraRTzGqyxJfYJwv+ZwqZNatAosdWQMP1GV8zvmkNlBe2JeZSaw0WYBHZk52pDpWC9qA==",
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.4.tgz",
+			"integrity": "sha512-46LaWACIctSfVKTu71ziFlqO8SVLhWGSxvaHpf0frfDTphSSpIfeNo5ZH/kJPHYJw4VgPGf/9c3zJN/FnCdaIQ==",
 			"dev": true,
 			"dependencies": {
-				"@inquirer/figures": "^1.0.3",
-				"@inquirer/type": "^1.4.0",
+				"@inquirer/figures": "^1.0.4",
+				"@inquirer/type": "^1.5.0",
 				"@types/mute-stream": "^0.0.4",
-				"@types/node": "^20.14.9",
+				"@types/node": "^20.14.11",
 				"@types/wrap-ansi": "^3.0.0",
 				"ansi-escapes": "^4.3.2",
 				"cli-spinners": "^2.9.2",
@@ -1259,18 +1259,18 @@
 			}
 		},
 		"node_modules/@inquirer/figures": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.3.tgz",
-			"integrity": "sha512-ErXXzENMH5pJt5/ssXV0DfWUZqly8nGzf0UcBV9xTnP+KyffE2mqyxIMBrZ8ijQck2nU0TQm40EQB53YreyWHw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.4.tgz",
+			"integrity": "sha512-R7Gsg6elpuqdn55fBH2y9oYzrU/yKrSmIsDX4ROT51vohrECFzTf2zw9BfUbOW8xjfmM2QbVoVYdTwhrtEKWSQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/type": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.4.0.tgz",
-			"integrity": "sha512-AjOqykVyjdJQvtfkNDGUyMYGF8xN50VUxftCQWsOyIo4DFRLr6VQhW0VItGI1JIyQGCGgIpKa7hMMwNhZb4OIw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.0.tgz",
+			"integrity": "sha512-L/UdayX9Z1lLN+itoTKqJ/X4DX5DaWu2Sruwt4XgZzMNv32x4qllbzMX4MbJlz0yxAQtU19UvABGOjmdq1u3qA==",
 			"dev": true,
 			"dependencies": {
 				"mute-stream": "^1.0.0"
@@ -1638,17 +1638,17 @@
 			}
 		},
 		"node_modules/@remix-run/router": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.17.1.tgz",
-			"integrity": "sha512-mCOMec4BKd6BRGBZeSnGiIgwsbLGp3yhVqAD8H+PxiRNEHgDpZb8J1TnrSDlg97t0ySKMQJTHCWBCmBpSmkF6Q==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.18.0.tgz",
+			"integrity": "sha512-L3jkqmqoSVBVKHfpGZmLrex0lxR5SucGA0sUfFzGctehw+S/ggL9L/0NnC5mw6P8HUWpFZ3nQw3cRApjjWx9Sw==",
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.1.tgz",
-			"integrity": "sha512-lncuC4aHicncmbORnx+dUaAgzee9cm/PbIqgWz1PpXuwc+sa1Ct83tnqUDy/GFKleLiN7ZIeytM6KJ4cAn1SxA==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.19.0.tgz",
+			"integrity": "sha512-JlPfZ/C7yn5S5p0yKk7uhHTTnFlvTgLetl2VxqE518QgyM7C9bSfFTYvB/Q/ftkq0RIPY4ySxTz+/wKJ/dXC0w==",
 			"cpu": [
 				"arm"
 			],
@@ -1658,9 +1658,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.1.tgz",
-			"integrity": "sha512-F/tkdw0WSs4ojqz5Ovrw5r9odqzFjb5LIgHdHZG65dFI1lWTWRVy32KDJLKRISHgJvqUeUhdIvy43fX41znyDg==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.19.0.tgz",
+			"integrity": "sha512-RDxUSY8D1tWYfn00DDi5myxKgOk6RvWPxhmWexcICt/MEC6yEMr4HNCu1sXXYLw8iAsg0D44NuU+qNq7zVWCrw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1670,9 +1670,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.1.tgz",
-			"integrity": "sha512-vk+ma8iC1ebje/ahpxpnrfVQJibTMyHdWpOGZ3JpQ7Mgn/3QNHmPq7YwjZbIE7km73dH5M1e6MRRsnEBW7v5CQ==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.19.0.tgz",
+			"integrity": "sha512-emvKHL4B15x6nlNTBMtIaC9tLPRpeA5jMvRLXVbl/W9Ie7HhkrE7KQjvgS9uxgatL1HmHWDXk5TTS4IaNJxbAA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1682,9 +1682,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.1.tgz",
-			"integrity": "sha512-IgpzXKauRe1Tafcej9STjSSuG0Ghu/xGYH+qG6JwsAUxXrnkvNHcq/NL6nz1+jzvWAnQkuAJ4uIwGB48K9OCGA==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.19.0.tgz",
+			"integrity": "sha512-fO28cWA1dC57qCd+D0rfLC4VPbh6EOJXrreBmFLWPGI9dpMlER2YwSPZzSGfq11XgcEpPukPTfEVFtw2q2nYJg==",
 			"cpu": [
 				"x64"
 			],
@@ -1694,9 +1694,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.1.tgz",
-			"integrity": "sha512-P9bSiAUnSSM7EmyRK+e5wgpqai86QOSv8BwvkGjLwYuOpaeomiZWifEos517CwbG+aZl1T4clSE1YqqH2JRs+g==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.19.0.tgz",
+			"integrity": "sha512-2Rn36Ubxdv32NUcfm0wB1tgKqkQuft00PtM23VqLuCUR4N5jcNWDoV5iBC9jeGdgS38WK66ElncprqgMUOyomw==",
 			"cpu": [
 				"arm"
 			],
@@ -1706,9 +1706,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.1.tgz",
-			"integrity": "sha512-5RnjpACoxtS+aWOI1dURKno11d7krfpGDEn19jI8BuWmSBbUC4ytIADfROM1FZrFhQPSoP+KEa3NlEScznBTyQ==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.19.0.tgz",
+			"integrity": "sha512-gJuzIVdq/X1ZA2bHeCGCISe0VWqCoNT8BvkQ+BfsixXwTOndhtLUpOg0A1Fcx/+eA6ei6rMBzlOz4JzmiDw7JQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1718,9 +1718,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.1.tgz",
-			"integrity": "sha512-8mwmGD668m8WaGbthrEYZ9CBmPug2QPGWxhJxh/vCgBjro5o96gL04WLlg5BA233OCWLqERy4YUzX3bJGXaJgQ==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.19.0.tgz",
+			"integrity": "sha512-0EkX2HYPkSADo9cfeGFoQ7R0/wTKb7q6DdwI4Yn/ULFE1wuRRCHybxpl2goQrx4c/yzK3I8OlgtBu4xvted0ug==",
 			"cpu": [
 				"arm64"
 			],
@@ -1730,9 +1730,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.1.tgz",
-			"integrity": "sha512-dJX9u4r4bqInMGOAQoGYdwDP8lQiisWb9et+T84l2WXk41yEej8v2iGKodmdKimT8cTAYt0jFb+UEBxnPkbXEQ==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.19.0.tgz",
+			"integrity": "sha512-GlIQRj9px52ISomIOEUq/IojLZqzkvRpdP3cLgIE1wUWaiU5Takwlzpz002q0Nxxr1y2ZgxC2obWxjr13lvxNQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1742,9 +1742,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.1.tgz",
-			"integrity": "sha512-V72cXdTl4EI0x6FNmho4D502sy7ed+LuVW6Ym8aI6DRQ9hQZdp5sj0a2usYOlqvFBNKQnLQGwmYnujo2HvjCxQ==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.19.0.tgz",
+			"integrity": "sha512-N6cFJzssruDLUOKfEKeovCKiHcdwVYOT1Hs6dovDQ61+Y9n3Ek4zXvtghPPelt6U0AH4aDGnDLb83uiJMkWYzQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1754,9 +1754,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.1.tgz",
-			"integrity": "sha512-f+pJih7sxoKmbjghrM2RkWo2WHUW8UbfxIQiWo5yeCaCM0TveMEuAzKJte4QskBp1TIinpnRcxkquY+4WuY/tg==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.19.0.tgz",
+			"integrity": "sha512-2DnD3mkS2uuam/alF+I7M84koGwvn3ZVD7uG+LEWpyzo/bq8+kKnus2EVCkcvh6PlNB8QPNFOz6fWd5N8o1CYg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1766,9 +1766,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.1.tgz",
-			"integrity": "sha512-qb1hMMT3Fr/Qz1OKovCuUM11MUNLUuHeBC2DPPAWUYYUAOFWaxInaTwTQmc7Fl5La7DShTEpmYwgdt2hG+4TEg==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.19.0.tgz",
+			"integrity": "sha512-D6pkaF7OpE7lzlTOFCB2m3Ngzu2ykw40Nka9WmKGUOTS3xcIieHe82slQlNq69sVB04ch73thKYIWz/Ian8DUA==",
 			"cpu": [
 				"s390x"
 			],
@@ -1778,9 +1778,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.1.tgz",
-			"integrity": "sha512-7O5u/p6oKUFYjRbZkL2FLbwsyoJAjyeXHCU3O4ndvzg2OFO2GinFPSJFGbiwFDaCFc+k7gs9CF243PwdPQFh5g==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.19.0.tgz",
+			"integrity": "sha512-HBndjQLP8OsdJNSxpNIN0einbDmRFg9+UQeZV1eiYupIRuZsDEoeGU43NQsS34Pp166DtwQOnpcbV/zQxM+rWA==",
 			"cpu": [
 				"x64"
 			],
@@ -1790,9 +1790,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.1.tgz",
-			"integrity": "sha512-pDLkYITdYrH/9Cv/Vlj8HppDuLMDUBmgsM0+N+xLtFd18aXgM9Nyqupb/Uw+HeidhfYg2lD6CXvz6CjoVOaKjQ==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.19.0.tgz",
+			"integrity": "sha512-HxfbvfCKJe/RMYJJn0a12eiOI9OOtAUF4G6ozrFUK95BNyoJaSiBjIOHjZskTUffUrB84IPKkFG9H9nEvJGW6A==",
 			"cpu": [
 				"x64"
 			],
@@ -1802,9 +1802,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.1.tgz",
-			"integrity": "sha512-W2ZNI323O/8pJdBGil1oCauuCzmVd9lDmWBBqxYZcOqWD6aWqJtVBQ1dFrF4dYpZPks6F+xCZHfzG5hYlSHZ6g==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.19.0.tgz",
+			"integrity": "sha512-HxDMKIhmcguGTiP5TsLNolwBUK3nGGUEoV/BO9ldUBoMLBssvh4J0X8pf11i1fTV7WShWItB1bKAKjX4RQeYmg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1814,9 +1814,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.1.tgz",
-			"integrity": "sha512-ELfEX1/+eGZYMaCIbK4jqLxO1gyTSOIlZr6pbC4SRYFaSIDVKOnZNMdoZ+ON0mrFDp4+H5MhwNC1H/AhE3zQLg==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.19.0.tgz",
+			"integrity": "sha512-xItlIAZZaiG/u0wooGzRsx11rokP4qyc/79LkAOdznGRAbOFc+SfEdfUOszG1odsHNgwippUJavag/+W/Etc6Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -1826,9 +1826,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.1.tgz",
-			"integrity": "sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.19.0.tgz",
+			"integrity": "sha512-xNo5fV5ycvCCKqiZcpB65VMR11NJB+StnxHz20jdqRAktfdfzhgjTiJ2doTDQE/7dqGaV5I7ZGqKpgph6lCIag==",
 			"cpu": [
 				"x64"
 			],
@@ -2092,9 +2092,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "20.14.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-			"integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+			"version": "20.14.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+			"integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -2888,18 +2888,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array.prototype.toreversed": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz",
-			"integrity": "sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"es-shim-unscopables": "^1.0.0"
 			}
 		},
 		"node_modules/array.prototype.tosorted": {
@@ -3979,9 +3967,9 @@
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.828",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.828.tgz",
-			"integrity": "sha512-QOIJiWpQJDHAVO4P58pwb133Cwee0nbvy/MV1CwzZVGpkH1RX33N3vsaWRCpR6bF63AAq366neZrRTu7Qlsbbw==",
+			"version": "1.4.832",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.832.tgz",
+			"integrity": "sha512-cTen3SB0H2SGU7x467NRe1eVcQgcuS6jckKfWJHia2eo0cHIGOqHoAxevIYZD4eRHcWjkvFzo93bi3vJ9W+1lA==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -4554,15 +4542,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-react": {
-			"version": "7.34.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.4.tgz",
-			"integrity": "sha512-Np+jo9bUwJNxCsT12pXtrGhJgT3T44T1sHhn1Ssr42XFn8TES0267wPGo5nNrMHi8qkyimDAX2BUmkf9pSaVzA==",
+			"version": "7.35.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz",
+			"integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
 			"dev": true,
 			"dependencies": {
 				"array-includes": "^3.1.8",
 				"array.prototype.findlast": "^1.2.5",
 				"array.prototype.flatmap": "^1.3.2",
-				"array.prototype.toreversed": "^1.1.2",
 				"array.prototype.tosorted": "^1.1.4",
 				"doctrine": "^2.1.0",
 				"es-iterator-helpers": "^1.0.19",
@@ -4583,7 +4570,7 @@
 				"node": ">=4"
 			},
 			"peerDependencies": {
-				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks": {
@@ -5130,9 +5117,9 @@
 			}
 		},
 		"node_modules/framer-motion": {
-			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.3.tgz",
-			"integrity": "sha512-Z+fwgwKveyjDXPpnNP0invAt0W8y2kYk7FHH3Vk2DxLtNVzBg8qhEvGapVeWZgcuvVnKvTKhJLX091mYdMzQBg==",
+			"version": "11.3.8",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.8.tgz",
+			"integrity": "sha512-1D+RDTsIp4Rz2dq/oToqSEc9idEQwgBRQyBq4rGpFba+0Z+GCbj9z1s0+ikFbanWe3YJ0SqkNlDe08GcpFGj5A==",
 			"dependencies": {
 				"tslib": "^2.4.0"
 			},
@@ -5915,9 +5902,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
-			"integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
+			"integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
 			"dev": true,
 			"dependencies": {
 				"hasown": "^2.0.2"
@@ -7074,9 +7061,9 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/msw": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/msw/-/msw-2.3.1.tgz",
-			"integrity": "sha512-ocgvBCLn/5l3jpl1lssIb3cniuACJLoOfZu01e3n5dbJrpA5PeeWn28jCLgQDNt6d7QT8tF2fYRzm9JoEHtiig==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/msw/-/msw-2.3.2.tgz",
+			"integrity": "sha512-vDn6d6a50vxPE+HnaKQfpmZ4SVXlOjF97yD5FJcUT3v2/uZ65qvTYNL25yOmnrfCNWZ4wtAS7EbtXxygMug2Tw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -7222,9 +7209,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.17.tgz",
+			"integrity": "sha512-Ww6ZlOiEQfPfXM45v17oabk77Z7mg5bOt7AjDyzy7RjK9OrLrLC8dyZQoAPEOtFX9SaNf1Tdvr5gRJWdTJj7GA==",
 			"dev": true
 		},
 		"node_modules/nopt": {
@@ -7807,19 +7794,25 @@
 			}
 		},
 		"node_modules/postcss-nested": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
-			"integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+			"integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.11"
+				"postcss-selector-parser": "^6.1.1"
 			},
 			"engines": {
 				"node": ">=12.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.14"
@@ -8179,11 +8172,11 @@
 			}
 		},
 		"node_modules/react-router": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.24.1.tgz",
-			"integrity": "sha512-PTXFXGK2pyXpHzVo3rR9H7ip4lSPZZc0bHG5CARmj65fTT6qG7sTngmb6lcYu1gf3y/8KxORoy9yn59pGpCnpg==",
+			"version": "6.25.1",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.25.1.tgz",
+			"integrity": "sha512-u8ELFr5Z6g02nUtpPAggP73Jigj1mRePSwhS/2nkTrlPU5yEkH1vYzWNyvSnSzeeE2DNqWdH+P8OhIh9wuXhTw==",
 			"dependencies": {
-				"@remix-run/router": "1.17.1"
+				"@remix-run/router": "1.18.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -8193,12 +8186,12 @@
 			}
 		},
 		"node_modules/react-router-dom": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.24.1.tgz",
-			"integrity": "sha512-U19KtXqooqw967Vw0Qcn5cOvrX5Ejo9ORmOtJMzYWtCT4/WOfFLIZGGsVLxcd9UkBO0mSTZtXqhZBsWlHr7+Sg==",
+			"version": "6.25.1",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.25.1.tgz",
+			"integrity": "sha512-0tUDpbFvk35iv+N89dWNrJp+afLgd+y4VtorJZuOCXK0kkCWjEvb3vTJM++SYvMEpbVwXKf3FjeVveVEb6JpDQ==",
 			"dependencies": {
-				"@remix-run/router": "1.17.1",
-				"react-router": "6.24.1"
+				"@remix-run/router": "1.18.0",
+				"react-router": "6.25.1"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -8488,9 +8481,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.1.tgz",
-			"integrity": "sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.19.0.tgz",
+			"integrity": "sha512-5r7EYSQIowHsK4eTZ0Y81qpZuJz+MUuYeqmmYmRMl1nwhdmbiYqt5jwzf6u7wyOzJgYqtCRMtVRKOtHANBz7rA==",
 			"dependencies": {
 				"@types/estree": "1.0.5"
 			},
@@ -8502,22 +8495,22 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.18.1",
-				"@rollup/rollup-android-arm64": "4.18.1",
-				"@rollup/rollup-darwin-arm64": "4.18.1",
-				"@rollup/rollup-darwin-x64": "4.18.1",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.18.1",
-				"@rollup/rollup-linux-arm-musleabihf": "4.18.1",
-				"@rollup/rollup-linux-arm64-gnu": "4.18.1",
-				"@rollup/rollup-linux-arm64-musl": "4.18.1",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.18.1",
-				"@rollup/rollup-linux-riscv64-gnu": "4.18.1",
-				"@rollup/rollup-linux-s390x-gnu": "4.18.1",
-				"@rollup/rollup-linux-x64-gnu": "4.18.1",
-				"@rollup/rollup-linux-x64-musl": "4.18.1",
-				"@rollup/rollup-win32-arm64-msvc": "4.18.1",
-				"@rollup/rollup-win32-ia32-msvc": "4.18.1",
-				"@rollup/rollup-win32-x64-msvc": "4.18.1",
+				"@rollup/rollup-android-arm-eabi": "4.19.0",
+				"@rollup/rollup-android-arm64": "4.19.0",
+				"@rollup/rollup-darwin-arm64": "4.19.0",
+				"@rollup/rollup-darwin-x64": "4.19.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.19.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.19.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.19.0",
+				"@rollup/rollup-linux-arm64-musl": "4.19.0",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.19.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.19.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.19.0",
+				"@rollup/rollup-linux-x64-gnu": "4.19.0",
+				"@rollup/rollup-linux-x64-musl": "4.19.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.19.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.19.0",
+				"@rollup/rollup-win32-x64-msvc": "4.19.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -8630,9 +8623,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"devOptional": true,
 			"bin": {
 				"semver": "bin/semver.js"
@@ -9360,9 +9353,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.5.tgz",
-			"integrity": "sha512-DlTxttYcogpDfx3tf/8jfnma1nfAYi2cBUYV2YNoPPecwmO3YGiFlOX9D8tGAu+EDF38ryBzvrDKU/BLMsUwbw==",
+			"version": "3.4.6",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.6.tgz",
+			"integrity": "sha512-1uRHzPB+Vzu57ocybfZ4jh5Q3SdlH7XW23J5sQoM9LhE9eIOlzxer/3XPSsycvih3rboRsvt0QCmzSrqyOYUIA==",
 			"dev": true,
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
@@ -9645,9 +9638,9 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "4.21.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.21.0.tgz",
-			"integrity": "sha512-ADn2w7hVPcK6w1I0uWnM//y1rLXZhzB9mr0a3OirzclKF1Wp6VzevUmzz/NRAWunOT6E8HrnpGY7xOfc6K57fA==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.22.1.tgz",
+			"integrity": "sha512-9tHNEa0Ov81YOopiVkcCJVz5TM6AEQ+CHHjFIktqPnE3NV0AHIkx+gh9tiCl58m/66wWxkOC9eltpa75J4lQPA==",
 			"dev": true,
 			"engines": {
 				"node": ">=16"
@@ -9755,9 +9748,9 @@
 			}
 		},
 		"node_modules/ufo": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
-			"integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw=="
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+			"integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
 		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",

--- a/src/@types/notification.ts
+++ b/src/@types/notification.ts
@@ -5,6 +5,7 @@ export type NotificationItemTypes = {
 	text: string;
 	date: string;
 	unread: boolean;
+	id: string;
 };
 
 export type NotificationProps = {

--- a/src/components/cards/NotificationItem.tsx
+++ b/src/components/cards/NotificationItem.tsx
@@ -1,11 +1,25 @@
 import { useState } from 'react';
 import { NotificationItemTypes } from '../../@types/notification';
+import { useAppDispatch } from '../../redux/hooks/hooks';
+import useToast from '../../hooks/useToast';
+import { DynamicData } from '../../@types/DynamicData';
+import {
+	markOneRead,
+	readOneNotification,
+} from '../../redux/features/notificationSlice';
 
-const NotificationItem = ({ text, date, unread }: NotificationItemTypes) => {
+const NotificationItem = ({
+	text,
+	date,
+	unread,
+	id,
+}: NotificationItemTypes) => {
 	const [expanded, setExpanded] = useState(false);
 	const [notificationText, setNotificationText] = useState(
 		text.length > 100 ? `${text.substring(0, 100)}...` : text,
 	);
+	const dispath = useAppDispatch();
+	const { showErrorMessage } = useToast();
 
 	const changeTextLength = () => {
 		if (expanded) {
@@ -17,8 +31,23 @@ const NotificationItem = ({ text, date, unread }: NotificationItemTypes) => {
 		}
 	};
 
+	const readNotification = async () => {
+		try {
+			await dispath(markOneRead(id)).unwrap();
+			dispath(readOneNotification(id));
+		} catch (e) {
+			const err = e as DynamicData;
+			showErrorMessage(
+				err?.data?.message ||
+					err?.message ||
+					'Unknown error occurred! Please try again!',
+			);
+		}
+	};
+
 	return (
 		<div
+			onClick={readNotification}
 			className={`p-5 w-full my-2 bg-neutral-white rounded-xl relative shadow-dark-lg`}
 		>
 			<div className="p-2 rounded-full bg-neutral-grey absolute right-2 top-5" />
@@ -29,9 +58,6 @@ const NotificationItem = ({ text, date, unread }: NotificationItemTypes) => {
 				{unread && (
 					<div className="py-1 px-3 rounded-full bg-action-success/20">New</div>
 				)}
-				{/* <div>
-					<X />
-				</div> */}
 			</div>
 			<div className="h-max w-full text-xs py-2 transition-transform">
 				{notificationText}

--- a/src/components/cards/NotificationSkeleton.tsx
+++ b/src/components/cards/NotificationSkeleton.tsx
@@ -1,0 +1,13 @@
+const NotificationSkeleton = () => {
+	return (
+		<div
+			aria-label="skeleton"
+			className="w-full h-36 rounded-xl mb-4 bg-neutral-grey/20 animate-pulse flex gap-5 flex-col p-5"
+		>
+			<div className="w-full h-[30%] bg-neutral-grey/20 rounded-lg" />
+			<div className="w-full h-[60%] bg-neutral-grey/20 rounded-lg" />
+		</div>
+	);
+};
+
+export default NotificationSkeleton;

--- a/src/pages/dashboard/seller/SellerDashboard.tsx
+++ b/src/pages/dashboard/seller/SellerDashboard.tsx
@@ -207,7 +207,7 @@ const SellerDashboard = () => {
 								Loss
 							</h2>
 							<WaterPercentCard
-								percent={Math.round(lossPercent * 100)}
+								percent={isNaN(lossPercent) ? 0 : Math.round(lossPercent * 100)}
 								background="bg-[#ffa500]"
 								borderColor="border-[#ffa500]/70"
 							/>
@@ -217,7 +217,11 @@ const SellerDashboard = () => {
 								Expired products
 							</h2>
 							<WaterPercentCard
-								percent={Math.round(expiredProductPercent * 100)}
+								percent={
+									isNaN(expiredProductPercent)
+										? 0
+										: Math.round(expiredProductPercent * 100)
+								}
 								background="bg-[#808080]"
 								borderColor="border-[#808080]/70"
 							/>

--- a/src/redux/features/notificationSlice.ts
+++ b/src/redux/features/notificationSlice.ts
@@ -1,15 +1,40 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { DynamicData } from '../../@types/DynamicData';
+import API from '../../utils/api';
 
 type NotificationState = {
 	notifications: Array<DynamicData> | null;
 	value: number;
+	isLoading: boolean;
 };
 
 const initialState: NotificationState = {
 	notifications: [],
 	value: 0,
+	isLoading: false,
 };
+
+export const markAllRead = createAsyncThunk(
+	'readAllNotification',
+	async (_, { rejectWithValue }) => {
+		try {
+			await API.patch('/notifications');
+		} catch (error) {
+			return rejectWithValue((error as DynamicData).message);
+		}
+	},
+);
+
+export const markOneRead = createAsyncThunk(
+	'readOneNotification',
+	async (id: string, { rejectWithValue }) => {
+		try {
+			await API.patch(`/notifications/${id}`);
+		} catch (error) {
+			return rejectWithValue((error as DynamicData).message);
+		}
+	},
+);
 
 const notificationSlice = createSlice({
 	name: 'notifications',
@@ -17,15 +42,47 @@ const notificationSlice = createSlice({
 	reducers: {
 		userNotification: (state, action: PayloadAction<Array<DynamicData>>) => {
 			state.notifications = action.payload;
-			state.value = action.payload.length;
+			state.value = action.payload.filter(
+				(data) => data?.unread === true,
+			).length;
 		},
 		addNotification: (state, action: PayloadAction<DynamicData>) => {
 			state.notifications = [action.payload, ...state.notifications!];
 			state.value += 1;
 		},
+		readOneNotification: (state, action: PayloadAction<string>) => {
+			state.notifications = state.notifications?.map((notification) => {
+				if (notification.id === action.payload) {
+					if (notification.unread) {
+						state.value -= 1;
+					} else {
+						state.value += 1;
+					}
+					return { ...notification, unread: !notification.unread };
+				}
+				return notification;
+			}) as DynamicData[];
+		},
+	},
+	extraReducers: (builder) => {
+		builder.addCase(markAllRead.pending, (state) => {
+			state.isLoading = true;
+		});
+		builder.addCase(markAllRead.fulfilled, (state) => {
+			state.value = 0;
+			state.notifications = state.notifications?.map((notification) => ({
+				...notification,
+				unread: false,
+			})) as DynamicData[];
+			state.isLoading = false;
+		});
+		builder.addCase(markAllRead.rejected, (state) => {
+			state.isLoading = false;
+		});
 	},
 });
 
-export const { userNotification, addNotification } = notificationSlice.actions;
+export const { userNotification, addNotification, readOneNotification } =
+	notificationSlice.actions;
 
 export default notificationSlice.reducer;

--- a/test/components/cards/NotificationSkeleton.test.tsx
+++ b/test/components/cards/NotificationSkeleton.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { it, expect, describe } from 'vitest';
+import NotificationSkeleton from '../../../src/components/cards/NotificationSkeleton';
+
+describe('Notification Skeleton Component', () => {
+	it('should render a skeleton', () => {
+		render(<NotificationSkeleton />);
+		expect(screen.getByLabelText('skeleton')).toBeInTheDocument();
+	});
+});

--- a/test/components/notifications/Notification.test.tsx
+++ b/test/components/notifications/Notification.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import Notification from '../../../src/components/notification/Notification';
-import { DynamicData } from '../../../src/@types/DynamicData';
 import { Toaster } from 'sonner';
-import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { DynamicData } from '../../../src/@types/DynamicData';
+import Notification from '../../../src/components/notification/Notification';
 
 vi.mock('socket.io-client');
 
@@ -105,7 +105,7 @@ describe('Notification Component', () => {
 						id: '1',
 						message: 'Test Notification 1',
 						createdAt: new Date(),
-						unread: true,
+						unread: false,
 					},
 					{
 						id: '2',
@@ -133,5 +133,43 @@ describe('Notification Component', () => {
 		expect(screen.getByLabelText('notification-tab')).toBeInTheDocument();
 		expect(screen.getByText('Test Notification 1')).toBeInTheDocument();
 		expect(screen.getByText('Test Notification 2')).toBeInTheDocument();
+
+		expect(screen.queryByText(/new/i)).not.toBeInTheDocument();
+	});
+
+	it('should show a skeleton', async () => {
+		const modifiedStore = mockStore({
+			notifications: {
+				notifications: [
+					{
+						id: '1',
+						message: 'Test Notification 1',
+						createdAt: new Date(),
+						unread: false,
+					},
+					{
+						id: '2',
+						message: 'Test Notification 2',
+						createdAt: new Date(),
+						unread: false,
+					},
+				],
+				value: 2,
+				isLoading: true,
+			},
+		});
+
+		render(
+			<Provider store={modifiedStore}>
+				<Notification />
+				<Toaster position="top-right" richColors />
+			</Provider>,
+		);
+		const user = userEvent.setup();
+
+		const bellIcon = screen.getByRole('img', { name: 'bell-image' });
+		await user.click(bellIcon);
+
+		expect(screen.getAllByLabelText('skeleton'));
 	});
 });

--- a/test/components/notifications/Notifications.test.tsx
+++ b/test/components/notifications/Notifications.test.tsx
@@ -1,16 +1,24 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { render, screen } from '@testing-library/react';
-import { it, expect, describe } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { it, expect, describe, vi } from 'vitest';
 import Notification from '../../../src/components/notification/Notification';
 import AllProvider from '../../Utils/AllProvider';
 import userEvent from '@testing-library/user-event';
 import { addNotification } from '../../../src/redux/features/notificationSlice';
 import { store } from '../../../src/redux/store';
-// import { NotificationTypes } from '../../../src/@types/notification';
+import { toast } from 'sonner';
+import { DynamicData } from '../../../src/@types/DynamicData';
 
 vi.spyOn(window.HTMLMediaElement.prototype, 'play').mockImplementation(() =>
 	Promise.resolve(),
 );
+
+vi.mock('sonner', () => ({
+	toast: {
+		error: vi.fn(),
+		success: vi.fn(),
+	},
+}));
 
 describe('Notification component', () => {
 	const renderComponent = () => {
@@ -20,11 +28,13 @@ describe('Notification component', () => {
 			bell: screen.getByRole('img'),
 		};
 	};
-	it('should render an notification component with a bell icon', () => {
+
+	it('should render a notification component with a bell icon', () => {
 		const { bell } = renderComponent();
 		expect(bell).toBeInTheDocument();
 	});
-	it('should show notification tab when a user click on the bell', async () => {
+
+	it('should show notification tab when a user clicks on the bell', async () => {
 		const notification = {
 			id: '1',
 			message: 'Test Notification',
@@ -39,8 +49,8 @@ describe('Notification component', () => {
 		expect(screen.getByText('Test Notification')).toBeInTheDocument();
 	});
 
-	it('should show a toast when new message', async () => {
-		renderComponent();
+	it('should show a toast when a new message is received', async () => {
+		const { bell, user } = renderComponent();
 		const socket = require('socket.io-client')(
 			import.meta.env.VITE_API_APP_ROOT_URL,
 		);
@@ -54,5 +64,42 @@ describe('Notification component', () => {
 
 		const notificatioNber = screen.getByLabelText('notification-number');
 		expect(notificatioNber).toHaveTextContent('1');
+
+		await user.click(bell);
+
+		const notificationCard = screen.getByText(/new/i);
+		await user.click(notificationCard);
+	});
+
+	it('should handle errors in readAllNotification function', async () => {
+		const { bell, user } = renderComponent();
+		await user.click(bell);
+		const markButton = screen.getByLabelText('mark-button');
+		vi.spyOn(store, 'dispatch').mockImplementationOnce(() => {
+			throw new Error('Error');
+		});
+		await user.click(markButton);
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalledWith(
+				'Unknown error occurred! Please try again!',
+			);
+		});
+	});
+	it('should handle errors in readAllNotification function', async () => {
+		const { bell, user } = renderComponent();
+		await user.click(bell);
+		const markButton = screen.getByLabelText('mark-button');
+		const error = { data: { message: 'Test error' } };
+		(vi.spyOn(store, 'dispatch') as DynamicData).mockImplementation(() => {
+			return {
+				unwrap: () => Promise.reject(error),
+			};
+		});
+		await user.click(markButton);
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalledWith(
+				'Unknown error occurred! Please try again!',
+			);
+		});
 	});
 });


### PR DESCRIPTION
Users may want to tidy up their notification panel

**As user,** I should be able to mark all my notifications as read
**So that,** I can keep my notifications panel clean

Given that the user is logged in, then when the user clicks on ‘Mark all as read’ the notification icon count should change to the bell component with no number attached to it

### How to test this?

- Clone the repo and cd into it, the checkout to `feat-read-notifications-187419019`
- Run `npm install`
- Then start the app and first login
- Then go ahead the open the notification pane and try to mark one/all notification you have as read or unread

### Pivot tracker Id

187419019