### PR TITLE
[FIX]: Subtract discount from price returned on single order

### DIFF
--- a/src/pages/dashboard/buyer/order/SingleOrders.tsx
+++ b/src/pages/dashboard/buyer/order/SingleOrders.tsx
@@ -89,7 +89,12 @@ const SingleOrders = () => {
 										<span className="text-primary-lightblue mr-1">
 											{item.sales.reduce(
 												(acc: number, sale: DynamicData) =>
-													acc + sale.soldProducts.price * sale.quantitySold,
+													acc +
+													(sale.soldProducts.price -
+														(sale.soldProducts.price *
+															sale.soldProducts.discount) /
+															100) *
+														sale.quantitySold,
 												0,
 											)}
 										</span>

--- a/test/pages/LandingProduct.test.tsx
+++ b/test/pages/LandingProduct.test.tsx
@@ -56,7 +56,7 @@ describe('Get all products', () => {
 			const product = db.products.create({
 				name: `Iphone ${item}`,
 				price: `10 ${item}`,
-				discount: `1 ${item}`,
+				discount: `1${item}`,
 			});
 			products.push(product);
 		});
@@ -115,6 +115,7 @@ describe('Get all products', () => {
 		expect(loader).not.toBeInTheDocument();
 
 		expect(name).toBeDefined();
+		expect(screen.getByText("11%")).toBeInTheDocument();
 	});
 
 	it('should display the minimum and maximum search fields', async () => {


### PR DESCRIPTION
Sustracted the discount from the price return on single order page

<img width="870" alt="Screenshot 2024-07-24 at 15 12 45" src="https://github.com/user-attachments/assets/f7bd8bbd-cba0-477d-a848-ceb735f8218a">
